### PR TITLE
BUGS-3865 - Adding web/.gitignore to ignored build products to prevent Integrated Composer errors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ upstream/web/
 /web/.editorconfig
 /web/.eslintignore
 /web/.eslintrc.json
+/web/.gitignore
 /web/.gitattributes
 /web/.ht.router.php
 /web/.htaccess


### PR DESCRIPTION
BUGS-3865